### PR TITLE
Use Send-MailMessage instead of SmtpClient / General Cleanup

### DIFF
--- a/Monitor-ADGroupMemberShip.ps1
+++ b/Monitor-ADGroupMemberShip.ps1
@@ -69,7 +69,10 @@
 	Specify the File where the Group are listed. DN, SID, GUID, or Domain\Name of the group are accepted.
 
 .PARAMETER EmailServer
-	Specify the Email Server IPAddress/FQDN.
+    Specify the Email Server IPAddress/FQDN.
+    
+.PARAMETER EmailPort
+    Specify the port for the Email Server
 
 .PARAMETER EmailTo
 	Specify the Email Address(es) of the Destination. Example: fxcat@fx.lab
@@ -343,7 +346,7 @@ Begin
 {
     try
     {
-        $SmtpCred = (Get-Credential);
+        $EmailCred = (Get-Credential);
         # Retrieve the Script name
         $ScriptName = $MyInvocation.MyCommand;
 
@@ -823,7 +826,7 @@ Process
                                 Body = $Body
                                 SmtpServer = $EmailServer
                                 Port = $EmailPort
-                                Credential = $SmtpCred
+                                Credential = $EmailCred
                             }
 
                             Send-MailMessage @mailParam -UseSsl -BodyAsHtml;
@@ -914,7 +917,7 @@ Process
                 Body = "<h2>See Report in Attachment</h2>"
                 SmtpServer = $EmailServer
                 Port = $EmailPort
-                Credential = $SmtpCred
+                Credential = $EmailCred
                 Attachments = $attachments
             }
 


### PR DESCRIPTION
Per issue #43 , `Send-MailMessage` is used instead of `SmtpClient` to enable sending emails through Office 365.  

Other changes include:
* The addition of an `EmailPort` parameter to provide to `Send-MailMessage`
* `Get-Credential` is called at the top of the **Begin** region so that credentials can be passed to `Send-MailMessage`
* General cleanup and formatting of the overall script (only dealing with fixing style inconsistencies, not changing actual functionality)